### PR TITLE
[Style] GSText 디자인 시스템을 구현했습니다. 

### DIFF
--- a/GitSpace/GSDesignSystem/GSText.swift
+++ b/GitSpace/GSDesignSystem/GSText.swift
@@ -25,8 +25,94 @@ public struct GSText: View {
     }
 
     public var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        switch style {
+        case .title1:
+            Text(.init(string))
+                .font(.system(size: GSTextConstants.title1Size))
+                .fontWeight(GSTextConstants.title1FontWeight)
+                .foregroundStyle(GSTextConstants.title1Color)
+        case .title2:
+            Text(.init(string))
+                .font(.system(size: GSTextConstants.title2Size))
+                .fontWeight(GSTextConstants.title2FontWeight)
+                .foregroundStyle(GSTextConstants.title2Color)
+        case .title3:
+            Text(.init(string))
+                .font(.system(size: GSTextConstants.title3Size))
+                .fontWeight(GSTextConstants.title3FontWeight)
+                .foregroundStyle(GSTextConstants.title3Color)
+        case .sectionTitle:
+            Text(.init(string))
+                .font(.system(size: GSTextConstants.sectionTitleSize))
+                .fontWeight(GSTextConstants.sectionTitleFontWeight)
+                .foregroundStyle(GSTextConstants.sectionTitleColor)
+        case .body1:
+            Text(.init(string))
+                .font(.system(size: GSTextConstants.body1Size))
+                .fontWeight(GSTextConstants.body1FontWeight)
+                .foregroundStyle(GSTextConstants.body1Color)
+        case .body2:
+            Text(.init(string))
+                .font(.system(size: GSTextConstants.body2Size))
+                .fontWeight(GSTextConstants.body2FontWeight)
+                .foregroundStyle(GSTextConstants.body2Color)
+        case .caption1:
+            Text(.init(string))
+                .font(.system(size: GSTextConstants.caption1Size))
+                .fontWeight(GSTextConstants.caption1FontWeight)
+                .foregroundStyle(GSTextConstants.caption1Color)
+        case .caption2:
+            Text(.init(string))
+                .font(.system(size: GSTextConstants.caption2Size))
+                .fontWeight(GSTextConstants.caption2FontWeight)
+                .foregroundStyle(GSTextConstants.caption2Color)
+        case .description:
+            Text(.init(string))
+                .font(.system(size: GSTextConstants.descriptionSize))
+                .fontWeight(GSTextConstants.descriptionFontWeight)
+                .foregroundStyle(GSTextConstants.descriptionColor)
+        }
     }
+}
+
+enum GSTextConstants {
+    static let title1Size: CGFloat = 28
+    static let title1FontWeight: Font.Weight = .semibold
+    static let title1Color: Color = Color.primary
+
+    static let title2Size: CGFloat = 20
+    static let title2FontWeight: Font.Weight = .semibold
+    static let title2Color: Color = Color.primary
+
+    static let title3Size: CGFloat = 16
+    static let title3FontWeight: Font.Weight = .semibold
+    static let title3Color: Color = Color.primary
+
+    static let sectionTitleSize: CGFloat = 13
+    static let sectionTitleFontWeight: Font.Weight = .regular
+    static let sectionTitleColor: Color = Color.gsGray2
+
+    static let body1Size: CGFloat = 16
+    static let body1FontWeight: Font.Weight = .regular
+    static let body1Color: Color = Color.primary
+
+    static let body2Size: CGFloat = 12
+    static let body2FontWeight: Font.Weight = .regular
+    static let body2Color: Color = Color.gsGray1
+
+    static let caption1Size: CGFloat = 13
+    static let caption1FontWeight: Font.Weight = .medium
+    static let caption1Color: Color = Color.gsGray2
+    static let caption1PrimaryColor: Color = Color.primary
+
+    static let caption2Size: CGFloat = 12
+    static let caption2FontWeight: Font.Weight = .regular
+    static let caption2Color: Color = Color.gsGray2
+    static let caption2PrimaryColor: Color = Color.primary
+
+    static let descriptionSize: CGFloat = 16
+    static let descriptionFontWeight: Font.Weight = .medium
+    static let descriptionColor: Color = Color.gsGray2
 }
 
 #Preview {

--- a/GitSpace/GSDesignSystem/GSText.swift
+++ b/GitSpace/GSDesignSystem/GSText.swift
@@ -7,11 +7,16 @@
 
 import SwiftUI
 
-struct GSText: View {
+public struct GSText: View {
 
-  
+    public enum GSTextStyle {
+        case title1, title2, title3, sectionTitle
+        case body1, body2
+        case caption1, caption2
+        case description
+    }
 
-    var body: some View {
+    public var body: some View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
     }
 }

--- a/GitSpace/GSDesignSystem/GSText.swift
+++ b/GitSpace/GSDesignSystem/GSText.swift
@@ -122,5 +122,15 @@ extension Color {
 }
 
 #Preview {
-    GSText()
+    VStack {
+        GSText(style: .title1, string: "타이틀1")
+        GSText(style: .title2, string: "타이틀2")
+        GSText(style: .title3, string: "타이틀3")
+        GSText(style: .sectionTitle, string: "섹션타이틀")
+        GSText(style: .body1, string: "바디1")
+        GSText(style: .body2, string: "바디2")
+        GSText(style: .caption1, string: "캡션1")
+        GSText(style: .caption2, string: "캡션2")
+        GSText(style: .description, string: "디스크립션")
+    }
 }

--- a/GitSpace/GSDesignSystem/GSText.swift
+++ b/GitSpace/GSDesignSystem/GSText.swift
@@ -115,6 +115,12 @@ enum GSTextConstants {
     static let descriptionColor: Color = Color.gsGray2
 }
 
+extension Color {
+    static let gsGray1 = Color("GSGray1")
+    static let gsGray2 = Color("GSGray2")
+    static let gsGray3 = Color("GSGray3")
+}
+
 #Preview {
     GSText()
 }

--- a/GitSpace/GSDesignSystem/GSText.swift
+++ b/GitSpace/GSDesignSystem/GSText.swift
@@ -1,0 +1,21 @@
+//
+//  GSText.swift
+//  GSDesignSystem
+//
+//  Created by 박제균 on 10/12/23.
+//
+
+import SwiftUI
+
+struct GSText: View {
+
+  
+
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    GSText()
+}

--- a/GitSpace/GSDesignSystem/GSText.swift
+++ b/GitSpace/GSDesignSystem/GSText.swift
@@ -9,11 +9,19 @@ import SwiftUI
 
 public struct GSText: View {
 
+    let style: GSTextStyle
+    let string: String
+
     public enum GSTextStyle {
         case title1, title2, title3, sectionTitle
         case body1, body2
         case caption1, caption2
         case description
+    }
+
+    init(style: GSTextStyle, string: String) {
+        self.style = style
+        self.string = string
     }
 
     public var body: some View {

--- a/GitSpace/GSDesignSystem/GSText.swift
+++ b/GitSpace/GSDesignSystem/GSText.swift
@@ -123,14 +123,14 @@ extension Color {
 
 #Preview {
     VStack {
-        GSText(style: .title1, string: "타이틀1")
-        GSText(style: .title2, string: "타이틀2")
-        GSText(style: .title3, string: "타이틀3")
-        GSText(style: .sectionTitle, string: "섹션타이틀")
-        GSText(style: .body1, string: "바디1")
-        GSText(style: .body2, string: "바디2")
-        GSText(style: .caption1, string: "캡션1")
-        GSText(style: .caption2, string: "캡션2")
-        GSText(style: .description, string: "디스크립션")
+        GSText(style: .title1, string: "Title1")
+        GSText(style: .title2, string: "Title2")
+        GSText(style: .title3, string: "Title3")
+        GSText(style: .sectionTitle, string: "SectionTitle")
+        GSText(style: .body1, string: "Body1")
+        GSText(style: .body2, string: "Body2")
+        GSText(style: .caption1, string: "Caption1")
+        GSText(style: .caption2, string: "Caption2")
+        GSText(style: .description, string: "Description")
     }
 }

--- a/GitSpace/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace/GitSpace.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		22CDB98F2AD7C9F400F22ADA /* GSText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDB98E2AD7C9F400F22ADA /* GSText.swift */; };
 		7E65A94F2ACEEA3200C9BEA3 /* GitSpaceApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E65A94E2ACEEA3200C9BEA3 /* GitSpaceApp.swift */; };
 		7E65A9512ACEEA3200C9BEA3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E65A9502ACEEA3200C9BEA3 /* ContentView.swift */; };
 		7E65A9532ACEEA3300C9BEA3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E65A9522ACEEA3300C9BEA3 /* Assets.xcassets */; };
@@ -57,6 +58,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		22CDB98E2AD7C9F400F22ADA /* GSText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSText.swift; sourceTree = "<group>"; };
 		7E65A94B2ACEEA3200C9BEA3 /* GitSpace.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitSpace.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E65A94E2ACEEA3200C9BEA3 /* GitSpaceApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitSpaceApp.swift; sourceTree = "<group>"; };
 		7E65A9502ACEEA3200C9BEA3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 			isa = PBXGroup;
 			children = (
 				7E65A9812ACEECC000C9BEA3 /* GSDesignSystem.h */,
+				22CDB98E2AD7C9F400F22ADA /* GSText.swift */,
 			);
 			path = GSDesignSystem;
 			sourceTree = "<group>";
@@ -256,7 +259,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1420;
+				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					7E65A94A2ACEEA3200C9BEA3 = {
 						CreatedOnToolsVersion = 14.2;
@@ -267,6 +270,7 @@
 					};
 					7E65A97E2ACEECC000C9BEA3 = {
 						CreatedOnToolsVersion = 14.2;
+						LastSwiftMigration = 1500;
 					};
 				};
 			};
@@ -342,6 +346,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				22CDB98F2AD7C9F400F22ADA /* GSText.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -365,6 +370,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -397,6 +403,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -425,6 +432,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -457,6 +465,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -539,6 +548,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -546,6 +556,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -555,6 +566,8 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Celan.GitSpace-Utilities";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -571,6 +584,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -578,6 +592,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -587,6 +602,8 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Celan.GitSpace-Utilities";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -601,6 +618,8 @@
 		7E65A9882ACEECC000C9BEA3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -608,6 +627,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -617,10 +637,13 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.Celan.GSDesignSystem;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -631,6 +654,8 @@
 		7E65A9892ACEECC000C9BEA3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -638,6 +663,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -647,6 +673,8 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.Celan.GSDesignSystem;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -713,7 +741,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				minimumVersion = 10.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/GitSpace/GitSpace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GitSpace/GitSpace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,21 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "abseil-cpp-swiftpm",
+      "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
-        "version" : "0.20220203.2"
-      }
-    },
-    {
-      "identity" : "boringssl-swiftpm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
-      "state" : {
-        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
-        "version" : "0.9.1"
+        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
+        "version" : "1.2022062300.0"
       }
     },
     {
@@ -32,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "7e80c25b51c2ffa238879b07fbfc5baa54bb3050",
-        "version" : "9.6.0"
+        "revision" : "837d4af6ead57cec1fc38007892500d3139c7556",
+        "version" : "10.16.0"
       }
     },
     {
@@ -41,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "c1cfde8067668027b23a42c29d11c246152fe046",
-        "version" : "9.6.0"
+        "revision" : "56f681586ff006a7982b53dc94082eea31971acf",
+        "version" : "10.16.0"
       }
     },
     {
@@ -64,12 +55,12 @@
       }
     },
     {
-      "identity" : "grpc-ios",
+      "identity" : "grpc-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-ios.git",
+      "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
-        "version" : "1.44.3-grpc"
+        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
+        "version" : "1.49.1"
       }
     },
     {
@@ -79,6 +70,15 @@
       "state" : {
         "revision" : "5ccda3981422a84186387dbb763ba739178b529c",
         "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
       }
     },
     {

--- a/GitSpace/GitSpace.xcodeproj/xcshareddata/xcschemes/GitSpace.xcscheme
+++ b/GitSpace/GitSpace.xcodeproj/xcshareddata/xcschemes/GitSpace.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/GitSpace/GitSpace/Assets.xcassets/GSGrayColors/Contents.json
+++ b/GitSpace/GitSpace/Assets.xcassets/GSGrayColors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GitSpace/GitSpace/Assets.xcassets/GSGrayColors/GSGray1.colorset/Contents.json
+++ b/GitSpace/GitSpace/Assets.xcassets/GSGrayColors/GSGray1.colorset/Contents.json
@@ -1,0 +1,41 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x97",
+          "green" : "0x8F",
+          "red" : "0x8D"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.494",
+          "green" : "0.451",
+          "red" : "0.443"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/GitSpace/GitSpace/Assets.xcassets/GSGrayColors/GSGray2.colorset/Contents.json
+++ b/GitSpace/GitSpace/Assets.xcassets/GSGrayColors/GSGray2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.706",
+          "green" : "0.682",
+          "red" : "0.659"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.494",
+          "green" : "0.451",
+          "red" : "0.443"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GitSpace/GitSpace/Assets.xcassets/GSGrayColors/GSGray3.colorset/Contents.json
+++ b/GitSpace/GitSpace/Assets.xcassets/GSGrayColors/GSGray3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.953",
+          "green" : "0.945",
+          "red" : "0.933"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.184",
+          "green" : "0.160",
+          "red" : "0.153"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 개요
<!-- 무슨 이유로 코드를 변경했는지
어떤 위험이나 장애가 발견되었는지
어떤 부분에 리뷰어가 집중하면 좋을지
관련 스크린샷
테스트 계획 또는 완료 사항 -->
<!-- 1. 먼저 해당 PR과 관련된 issue를 멘션해주세요. -->
<!-- (예시) 
- @issueNumber
- 메인 홈 뷰의 UI를 전체 구현했습니다. 
-->

- #7 
- 디자인시스템 컴포넌트 GSText를 구현했습니다.

## ✏️ 작업 사항
<!-- 2. 작업한 내용을 작성해주세요. -->
<!-- (예시)
- 관리자용 대시보드 구현
- 관리자용 권한 수정 버튼 추가
-->

- GSText 스타일 별 구현
  - Title1
  - Title2
  - Title3
  - Section Title
  - Body1
  - Body2
  - Caption1
  - Caption2
  - Description
- 임시 Color Extension 추가
- 임시 GSGray 에셋 추가
- 다크모드 지원

## 📸 스크린샷 (optional)
<!-- 3. 작업한 사항을 시각적으로 보여줄 수 있다면 첨부 해주세요. -->
| Light Mode | Dark Mode |
| :--: | :--: | 
| ![스크린샷 2023-10-12 오후 9 18 20](https://github.com/GitSpacer/GitSpace/assets/19788294/cd5662a5-265e-49be-af74-5e9008723479) | ![스크린샷 2023-10-12 오후 9 18 35](https://github.com/GitSpacer/GitSpace/assets/19788294/1d5bb5cf-2f82-4dab-9f5d-af87e15c98de) |

## 특이사항
기존 프로젝트 코드에 작성된 GSText의 Style과 Figma에 정리된 Style의 갯수가 다릅니다.
현재는 Figma를 기준으로 Style을 정의 및 구현해 두었습니다.



