### PR TITLE
[Style] GSButton의 Tab 스타일에 언더라인을 추가했습니다.

### DIFF
--- a/GitSpace/GSDesignSystem/GSButton.swift
+++ b/GitSpace/GSDesignSystem/GSButton.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import GSUtilities
 
 public struct GSButton<Label: View>: View {
-    public enum Style {
+    public enum GSButtonStyle {
         case primary(ableState: AbleState)
         case secondary(ableState: AbleState)
         case tag(tagState: TagState)
@@ -38,12 +38,12 @@ public struct GSButton<Label: View>: View {
         }
     }
     
-    let style: Style
+    let style: GSButtonStyle
     let action: () -> Void
     let label: Label
     
     public init(
-        style: Style,
+        style: GSButtonStyle,
         action: @escaping () -> Void,
         @ViewBuilder label: () -> Label
     ) {
@@ -78,9 +78,9 @@ public struct GSButton<Label: View>: View {
 
 extension GSButton {
     struct GSButtonLabelModifier: ViewModifier {
-        let style: Style
+        let style: GSButtonStyle
         
-        init(_ style: Style) {
+        init(_ style: GSButtonStyle) {
             self.style = style
         }
         
@@ -140,10 +140,10 @@ extension GSButton {
 // MARK: - Foreground + Background Color Modifier
 extension GSButton.GSButtonLabelModifier {
     struct GSButtonLabelColorModifier: ViewModifier {
-        let style: GSButton.Style
+        let style: GSButton.GSButtonStyle
         @Environment(\.colorScheme) var colorScheme
         
-        init(_ style: GSButton.Style) {
+        init(_ style: GSButton.GSButtonStyle) {
             self.style = style
         }
         

--- a/GitSpace/GSDesignSystem/GSButton.swift
+++ b/GitSpace/GSDesignSystem/GSButton.swift
@@ -8,6 +8,11 @@
 import SwiftUI
 import GSUtilities
 
+public enum GSTab {
+    case starred
+    case activity
+}
+
 public struct GSButton<Label: View>: View {
     public enum GSButtonStyle {
         case primary(ableState: AbleState)

--- a/GitSpace/GSDesignSystem/GSButton.swift
+++ b/GitSpace/GSDesignSystem/GSButton.swift
@@ -19,7 +19,7 @@ public struct GSButton<Label: View>: View {
         case secondary(ableState: AbleState)
         case tag(tagState: TagState)
         case plain(destructiveState: DestructiveState)
-        case tab
+        case tab(tabName: GSTab, selectedTab: Binding<GSTab>)
         
         public enum AbleState {
             case enabled	
@@ -131,12 +131,20 @@ extension GSButton {
                     )
                     .modifier(GSButtonLabelColorModifier(style))
                 
-            case .tab:
+            case let .tab(tabName, selectedTab):
                 content
                     .font(
                         .system(size: 20, weight: .medium)
                     )
                     .modifier(GSButtonLabelColorModifier(style))
+                    .overlay(alignment: .bottom) {
+                        if tabName == selectedTab.wrappedValue {
+                            Rectangle()
+                                .foregroundColor(.primary)
+                                .frame(height: 3)
+                                .offset(y: 8)
+                        }
+                    }
             }
         }
     }
@@ -171,7 +179,7 @@ extension GSButton.GSButtonLabelModifier {
                     case .disabled:
                         content
                             .foregroundColor(.white)
-                            .background(Color.gsGray1)
+                            .background(Color.gsGrey1)
                     }
                     
                 case let .tag(tagState):
@@ -233,7 +241,7 @@ extension GSButton.GSButtonLabelModifier {
                     case .disabled:
                         content
                             .foregroundColor(.white)
-                            .background(Color.gsGray1)
+                            .background(Color.gsGrey1)
                     }
                     
                 case let .tag(tagState):
@@ -241,7 +249,7 @@ extension GSButton.GSButtonLabelModifier {
                     case .idle:
                         content
                             .foregroundColor(.white)
-                            .background(Color.gsGray2)
+                            .background(Color.gsGrey2)
                         
                     case let .editing(activityState):
                         switch activityState {
@@ -341,10 +349,15 @@ struct GSButton_Previews: PreviewProvider {
             } label: {
                 Text("Plain Destructive")
             }
-            GSButton(style: .tab) {
+            GSButton(style: .tab(tabName: .starred, selectedTab: .constant(.starred))) {
                 
             } label: {
-                Text("Tab")
+                Text("Tab Starred")
+            }
+            GSButton(style: .tab(tabName: .activity, selectedTab: .constant(.starred))) {
+                
+            } label: {
+                Text("Tab Activity")
             }
         }
     }

--- a/GitSpace/GSDesignSystem/GSCanvas.swift
+++ b/GitSpace/GSDesignSystem/GSCanvas.swift
@@ -37,7 +37,7 @@ extension GSCanvas {
             case .light:
                 Color.white
             case.dark:
-                Color.gsGray2
+                Color.gsGrey2
             default:
                 Color.white
             }
@@ -53,7 +53,7 @@ extension GSCanvas {
                             .fill(backgroundColorByColorScheme)
                             .frame(maxWidth: .infinity)
                             .frame(minWidth: 50)
-                            .shadow(color: Color.gsGray2.opacity(0.3), radius: 6, x:0, y:2)
+                            .shadow(color: Color.gsGrey2.opacity(0.3), radius: 6, x:0, y:2)
                     )
             }
         }

--- a/GitSpace/GSDesignSystem/GSText.swift
+++ b/GitSpace/GSDesignSystem/GSText.swift
@@ -76,13 +76,6 @@ public struct GSText: View {
     }
 }
 
-// !!!: AssetColor와 CodeBase Color 중 어떤 방식으로 할지 논의 필요!
-extension Color {
-    static let gsGray1 = Color("GSGray1")
-    static let gsGray2 = Color("GSGray2")
-    static let gsGray3 = Color("GSGray3")
-}
-
 #Preview {
     VStack {
         GSText(style: .title1, string: "Title1")

--- a/GitSpace/GSUtilities/Extensions/Color+.swift
+++ b/GitSpace/GSUtilities/Extensions/Color+.swift
@@ -36,7 +36,11 @@ public extension Color {
     static let gsGreenPrimary: Color = .init(hex: "#BDFF01")
     static let gsGreenSecondary: Color = .init(hex: "#E0FF66")
     static let gsYellow: Color = .init(hex: "#FAFF10")
-    static let gsGray1: Color = .init(hex: "#8D8F97")
-    static let gsGray2: Color = .init(hex: "#27292E")
+    static let gsGrey1: Color = .init(hex: "#8D8F97")
+    static let gsGrey2: Color = .init(hex: "#27292E")
     static let gsRed: Color = .init(hex: "#FF6C2E")
+    
+    static let gsGray1 = Color("GSGray1")
+    static let gsGray2 = Color("GSGray2")
+    static let gsGray3 = Color("GSGray3")
 }

--- a/GitSpace/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace/GitSpace.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		6E7E3BF52AD35A7700152EAE /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 6E7E3BF42AD35A7700152EAE /* FirebaseFirestore */; };
 		6E7E3BF72AD35A7700152EAE /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 6E7E3BF62AD35A7700152EAE /* FirebaseFirestoreSwift */; };
 		6E7E3BF92AD35A7700152EAE /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 6E7E3BF82AD35A7700152EAE /* FirebaseMessaging */; };
+		6EB4CA362AE575970050A912 /* GSUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E65A96B2ACEEB7600C9BEA3 /* GSUtilities.framework */; platformFilter = ios; };
+		6EB4CA372AE575970050A912 /* GSUtilities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7E65A96B2ACEEB7600C9BEA3 /* GSUtilities.framework */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7E65A94F2ACEEA3200C9BEA3 /* GitSpaceApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E65A94E2ACEEA3200C9BEA3 /* GitSpaceApp.swift */; };
 		7E65A9512ACEEA3200C9BEA3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E65A9502ACEEA3200C9BEA3 /* ContentView.swift */; };
 		7E65A9532ACEEA3300C9BEA3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E65A9522ACEEA3300C9BEA3 /* Assets.xcassets */; };
@@ -30,6 +32,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		6EB4CA382AE575970050A912 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7E65A9432ACEEA3200C9BEA3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E65A96A2ACEEB7600C9BEA3;
+			remoteInfo = GSUtilities;
+		};
 		7E65A96F2ACEEB7600C9BEA3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7E65A9432ACEEA3200C9BEA3 /* Project object */;
@@ -47,6 +56,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		6EB4CA3A2AE575970050A912 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				6EB4CA372AE575970050A912 /* GSUtilities.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7E65A9762ACEEB7600C9BEA3 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -104,6 +124,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6EB4CA362AE575970050A912 /* GSUtilities.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -118,6 +139,13 @@
 			path = Constant;
 			sourceTree = "<group>";
 		};
+		6EB4CA352AE575970050A912 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		7E65A9422ACEEA3200C9BEA3 = {
 			isa = PBXGroup;
 			children = (
@@ -125,6 +153,7 @@
 				7E65A9802ACEECC000C9BEA3 /* GSDesignSystem */,
 				7E65A96C2ACEEB7600C9BEA3 /* GSUtilities */,
 				7E65A94C2ACEEA3200C9BEA3 /* Products */,
+				6EB4CA352AE575970050A912 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -261,10 +290,12 @@
 				7E65A97B2ACEECC000C9BEA3 /* Sources */,
 				7E65A97C2ACEECC000C9BEA3 /* Frameworks */,
 				7E65A97D2ACEECC000C9BEA3 /* Resources */,
+				6EB4CA3A2AE575970050A912 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				6EB4CA392AE575970050A912 /* PBXTargetDependency */,
 			);
 			name = GSDesignSystem;
 			productName = GSDesignSystem;
@@ -377,6 +408,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		6EB4CA392AE575970050A912 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = 7E65A96A2ACEEB7600C9BEA3 /* GSUtilities */;
+			targetProxy = 6EB4CA382AE575970050A912 /* PBXContainerItemProxy */;
+		};
 		7E65A9702ACEEB7600C9BEA3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 7E65A96A2ACEEB7600C9BEA3 /* GSUtilities */;


### PR DESCRIPTION
## 개요
<!-- 무슨 이유로 코드를 변경했는지
어떤 위험이나 장애가 발견되었는지
어떤 부분에 리뷰어가 집중하면 좋을지
관련 스크린샷
테스트 계획 또는 완료 사항 -->
<!-- 1. 먼저 해당 PR과 관련된 issue를 멘션해주세요. -->
<!-- (예시) 
- @issueNumber
- 메인 홈 뷰의 UI를 전체 구현했습니다. 
-->

- #13 
- GSButton의 TabStyle에 언더라인을 추가했습니다.

## ✏️ 작업 사항
<!-- 2. 작업한 내용을 작성해주세요. -->
<!-- (예시)
- 관리자용 대시보드 구현
- 관리자용 권한 수정 버튼 추가
-->

- Style 타입 이름 수정 Style -> GSButtonStyle
- Color 익스텐션 Ambiguous 에러 정리
- Tab 스타일 버튼 언더라인 추가

## 📸 스크린샷 (optional)
<!-- 3. 작업한 사항을 시각적으로 보여줄 수 있다면 첨부 해주세요. -->
| GSButton_Tab 스타일 |
| :--: | 
| <img src="https://github.com/GitSpacer/GitSpace/assets/45925685/20a7ddf8-3f66-48a6-9afb-7c3b762d236e" width=300> |



## 주요 로직 (optional)
<!-- 4. 작업한 사항을 시각적으로 보여줄 수 있다면 첨부 해주세요. -->
##### GSButton
- GSTab 타입이 추가되었습니다. GitSpace 모듈에서 GSTab 타입의 프로퍼티 사용이 필요하여 제네릭을 구현하지 않아도 되도록 GSButton 외부에 위치시켰습니다.
- 버튼이 초기화될 때 전달받은 tab 케이스와 외부에서 바인딩된 selectedTab을 비교하여 언더라인을 overlay 합니다.

``` swift
public enum GSTab {
    case starred
    case activity
}

public struct GSButton<Label: View>: View {
    public enum GSButtonStyle {
        ...
        case tab(tabName: GSTab, selectedTab: Binding<GSTab>)
        ...
    }
}

case let .tab(tabName, selectedTab):
    content
        .font(
            .system(size: 20, weight: .medium)
        )
        .modifier(GSButtonLabelColorModifier(style))
        .overlay(alignment: .bottom) {
            if tabName == selectedTab.wrappedValue {
                Rectangle()
                    .foregroundColor(.primary)
                    .frame(height: 3)
                    .offset(y: 8)
            }
        }
```

##### GitSpace 모듈에서 구현 예시
- 아래와 같이 View에서 사용할 때, 바인딩 용도의 selectedTab 프로퍼티가 필요합니다.
- Button의 action에서 언더라인을 원하는 버튼으로 selectedTab을 변경해주면 스크린샷과 동일하게 Tab 버튼 UI가 다시 렌더링됩니다.

```swift
struct ContentView: View {
    @State var selectedTab: GSTab = .starred
    
    var body: some View {
        VStack {
            HStack {
                GSButton(style: .tab(tabName: .starred, selectedTab: $selectedTab)) {
                    selectedTab = .starred
                } label: {
                    Text("Starred")
                }
                
                GSButton(style: .tab(tabName: .activity, selectedTab: $selectedTab)) {
                    selectedTab = .activity
                } label: {
                    Text("Activity")
                }
            }
        }
        .padding()
    }
}
```

## 논의사항
현재 Asset Color와 hex init Color가 섞여서 사용되고 있고, 동일하게 `gsGray`라는 이름을 사용하고 있어서 Ambiguous 에러가 발생합니다. 임시적으로 hex Color로 초기화 된 정적 변수 이름을 `gsGrey`로 변경하였고, 회의 과정에서 Color 사용 방식에 대한 논의가 필요합니다.

```diff
extension Color {
-     static let gsGray1: Color = .init(hex: "#8D8F97")
-     static let gsGray2: Color = .init(hex: "#27292E")

+     static let gsGrey1: Color = .init(hex: "#8D8F97")
+     static let gsGrey2: Color = .init(hex: "#27292E")
+     static let gsGray1 = Color("GSGray1")
+     static let gsGray2 = Color("GSGray2")
+     static let gsGray3 = Color("GSGray3")
}
```