### PR TITLE
#17/feat network client abstracted object impl

### DIFF
--- a/GitSpace/GSUtilities/NetworkClients/ApiTransferable.swift
+++ b/GitSpace/GSUtilities/NetworkClients/ApiTransferable.swift
@@ -9,56 +9,56 @@ import Foundation
 import SwiftUI
 
 private protocol GSApiTransferable<T> {
-    associatedtype T: Codable
-    var create: () async throws -> T? { get set }
-    var read: () async throws -> T? { get set }
-    var delete: () async throws -> T? { get set }
-    var update: () async throws -> T? { get set }
+  associatedtype T: Codable
+  var create: () async throws -> T? { get set }
+  var read: () async throws -> T? { get set }
+  var delete: () async throws -> T? { get set }
+  var update: () async throws -> T? { get set }
 }
 
 public struct GSFirebaseClient<T: Codable>: GSApiTransferable {
-    public var create: () async throws -> T?
-    public var read: () async throws -> T?
-    public var delete: () async throws -> T?
-    public var update: () async throws -> T?
-    
-    public init(
-        create: @escaping () -> T? = { return nil },
-        read: @escaping () -> T? = { return nil },
-        delete: @escaping () -> T? = { return nil },
-        update: @escaping () -> T? = { return nil }
-    ) {
-        self.create = create
-        self.read = read
-        self.delete = delete
-        self.update = update
-    }
+  public var create: () async throws -> T?
+  public var read: () async throws -> T?
+  public var delete: () async throws -> T?
+  public var update: () async throws -> T?
+  
+  public init(
+    create: @escaping () -> T? = { return nil },
+    read: @escaping () -> T? = { return nil },
+    delete: @escaping () -> T? = { return nil },
+    update: @escaping () -> T? = { return nil }
+  ) {
+    self.create = create
+    self.read = read
+    self.delete = delete
+    self.update = update
+  }
 }
 
 // MARK: Additional Helpers
 extension GSFirebaseClient {
-    public func fetchAll() -> [T] {
-        return []
-    }
+  public func fetchAll() -> [T] {
+    return []
+  }
 }
 
 public struct GSGitHubClient<T: Codable>: GSApiTransferable {
-    public var create: () async throws -> T?
-    public var read: () async throws -> T?
-    public var delete: () async throws -> T?
-    public var update: () async throws -> T?
-    
-    public init(
-        create: @escaping () -> T? = { return nil },
-        read: @escaping () -> T? = { return nil },
-        delete: @escaping () -> T? = { return nil },
-        update: @escaping () -> T? = { return nil }
-    ) {
-        self.create = create
-        self.read = read
-        self.delete = delete
-        self.update = update
-    }
+  public var create: () async throws -> T?
+  public var read: () async throws -> T?
+  public var delete: () async throws -> T?
+  public var update: () async throws -> T?
+  
+  public init(
+    create: @escaping () -> T? = { return nil },
+    read: @escaping () -> T? = { return nil },
+    delete: @escaping () -> T? = { return nil },
+    update: @escaping () -> T? = { return nil }
+  ) {
+    self.create = create
+    self.read = read
+    self.delete = delete
+    self.update = update
+  }
 }
 
 struct ModelSample: Codable { }
@@ -66,14 +66,14 @@ struct GitHubModel: Codable { }
 struct FirebaseModel: Codable { }
 
 private struct MyView: View {
-    let firebaseClient: some GSApiTransferable = GSFirebaseClient(
-        create: { return ModelSample() },
-        read: { return ModelSample() }
-    )
-    
-    let githubClient: some GSApiTransferable = GSGitHubClient<GitHubModel>()
-    
-    var body: some View {
-        VStack { }
-    }
+  let firebaseClient: some GSApiTransferable = GSFirebaseClient(
+    create: { return ModelSample() },
+    read: { return ModelSample() }
+  )
+  
+  let githubClient: some GSApiTransferable = GSGitHubClient<GitHubModel>()
+  
+  var body: some View {
+    VStack { }
+  }
 }

--- a/GitSpace/GSUtilities/NetworkClients/ApiTransferable.swift
+++ b/GitSpace/GSUtilities/NetworkClients/ApiTransferable.swift
@@ -6,3 +6,74 @@
 //
 
 import Foundation
+import SwiftUI
+
+private protocol GSApiTransferable<T> {
+    associatedtype T: Codable
+    var create: () async throws -> T? { get set }
+    var read: () async throws -> T? { get set }
+    var delete: () async throws -> T? { get set }
+    var update: () async throws -> T? { get set }
+}
+
+public struct GSFirebaseClient<T: Codable>: GSApiTransferable {
+    public var create: () async throws -> T?
+    public var read: () async throws -> T?
+    public var delete: () async throws -> T?
+    public var update: () async throws -> T?
+    
+    public init(
+        create: @escaping () -> T? = { return nil },
+        read: @escaping () -> T? = { return nil },
+        delete: @escaping () -> T? = { return nil },
+        update: @escaping () -> T? = { return nil }
+    ) {
+        self.create = create
+        self.read = read
+        self.delete = delete
+        self.update = update
+    }
+}
+
+// MARK: Additional Helpers
+extension GSFirebaseClient {
+    public func fetchAll() -> [T] {
+        return []
+    }
+}
+
+public struct GSGitHubClient<T: Codable>: GSApiTransferable {
+    public var create: () async throws -> T?
+    public var read: () async throws -> T?
+    public var delete: () async throws -> T?
+    public var update: () async throws -> T?
+    
+    public init(
+        create: @escaping () -> T? = { return nil },
+        read: @escaping () -> T? = { return nil },
+        delete: @escaping () -> T? = { return nil },
+        update: @escaping () -> T? = { return nil }
+    ) {
+        self.create = create
+        self.read = read
+        self.delete = delete
+        self.update = update
+    }
+}
+
+struct ModelSample: Codable { }
+struct GitHubModel: Codable { }
+struct FirebaseModel: Codable { }
+
+private struct MyView: View {
+    let firebaseClient: some GSApiTransferable = GSFirebaseClient(
+        create: { return ModelSample() },
+        read: { return ModelSample() }
+    )
+    
+    let githubClient: some GSApiTransferable = GSGitHubClient<GitHubModel>()
+    
+    var body: some View {
+        VStack { }
+    }
+}

--- a/GitSpace/GSUtilities/NetworkClients/ApiTransferable.swift
+++ b/GitSpace/GSUtilities/NetworkClients/ApiTransferable.swift
@@ -1,0 +1,8 @@
+//
+//  ApiTransferable.swift
+//  GSUtilities
+//
+//  Created by Celan on 12/24/23.
+//
+
+import Foundation

--- a/GitSpace/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace/GitSpace.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		7E65A9822ACEECC000C9BEA3 /* GSDesignSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E65A9812ACEECC000C9BEA3 /* GSDesignSystem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7E65A9852ACEECC000C9BEA3 /* GSDesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E65A97F2ACEECC000C9BEA3 /* GSDesignSystem.framework */; };
 		7E65A9862ACEECC000C9BEA3 /* GSDesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7E65A97F2ACEECC000C9BEA3 /* GSDesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7EECAF112B37F5580073A073 /* ApiTransferable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EECAF102B37F5580073A073 /* ApiTransferable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +80,7 @@
 		7E65A9782ACEEBBF00C9BEA3 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		7E65A97F2ACEECC000C9BEA3 /* GSDesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GSDesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E65A9812ACEECC000C9BEA3 /* GSDesignSystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GSDesignSystem.h; sourceTree = "<group>"; };
+		7EECAF102B37F5580073A073 /* ApiTransferable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiTransferable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +166,7 @@
 			isa = PBXGroup;
 			children = (
 				7E65A96D2ACEEB7600C9BEA3 /* GitSpace_Utilities.h */,
+				7EECAF0F2B37F5180073A073 /* NetworkClients */,
 				6E652F432AD8218C008F8151 /* Constant */,
 				7E65A9772ACEEB9900C9BEA3 /* Extensions */,
 			);
@@ -188,6 +191,14 @@
 				6E61F9322AD81A48001C7FF3 /* GSCanvas.swift */,
 			);
 			path = GSDesignSystem;
+			sourceTree = "<group>";
+		};
+		7EECAF0F2B37F5180073A073 /* NetworkClients */ = {
+			isa = PBXGroup;
+			children = (
+				7EECAF102B37F5580073A073 /* ApiTransferable.swift */,
+			);
+			path = NetworkClients;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -388,6 +399,7 @@
 				7E65A9792ACEEBBF00C9BEA3 /* String+.swift in Sources */,
 				6E61F9352AD81CC6001C7FF3 /* Color+.swift in Sources */,
 				6E652F452AD821B1008F8151 /* Constant.swift in Sources */,
+				7EECAF112B37F5580073A073 /* ApiTransferable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## 개요
- #17 
- 이상하고 아름다운 `GSApiTransferable` 프로토콜을 구현합니다.
- 해당 프로토콜을 채택하는 객체 혹은 구조체를 인스턴스화하여 필요한 타입을 CRUD 할 수 있습니다.
  - CRUD 로직은 `GSApiTransferable` 프로토콜의 인스턴스를 생성하며 클로저를 주입하는 방식으로 구현합니다.
  - GitHub과 Firebase 등의 네트워크 통신에 모두 대응할 수 있습니다.
  - 기본 생성하는 로직인 CRUD를 제외하면, 다른 로직을 `GSApiTransferable` 프로토콜을 채택하는 타입을 확장하여 구현합니다.
  - 경우에 따라, 모델 타입 자체에서 구현하는 것도 좋아 보입니다..?

- 용례
  - `GSApiTransferable` 프로토콜을 채택하는 구조체는 `Codable`을 채택하는 타입을 제너릭으로 받습니다.
  - Knock, UserInfo, Chat 등등 모든 타입을 생성하는 시점에 제공함으로써 초기화 가능합니다.
  - 초기화할 땐, 필요한 로직만 클로저를 주입할 수 있습니다(CRUD 중에 R만 필요한 경우).

---

## ✏️ 작업 사항
```swift
/*--------------------*/
/*---protocol Layer---*/
/*--------------------*/
private protocol GSApiTransferable<T> {
  associatedtype T: Codable
  var create: () async throws -> T? { get set }
  var read: () async throws -> T? { get set }
  var delete: () async throws -> T? { get set }
  var update: () async throws -> T? { get set }
}

public struct GSFirebaseClient<T: Codable>: GSApiTransferable {
  public var create: () async throws -> T?
  public var read: () async throws -> T?
  public var delete: () async throws -> T?
  public var update: () async throws -> T?
  
  public init(
    create: @escaping () -> T? = { return nil },
    read: @escaping () -> T? = { return nil },
    delete: @escaping () -> T? = { return nil },
    update: @escaping () -> T? = { return nil }
  ) {
    self.create = create
    self.read = read
    self.delete = delete
    self.update = update
  }
}

// MARK: Additional Helpers
extension GSFirebaseClient {
  // 요런 식으로 Client를 확장하여 필요한 로직을 추가 제공
  public func fetchAll() -> [T] {
    return []
  }
}

/*-----------------*/
/*---Model Layer---*/
/*-----------------*/
struct ModelSample: Codable { }
struct GitHubModel: Codable { }
struct FirebaseModel: Codable { }

/*----------------*/
/*---View Layer---*/
/*----------------*/
private struct MyView: View {
  let firebaseClient: some GSApiTransferable = GSFirebaseClient(
      create: { return ModelSample() },
      read: { return ModelSample() }
  )
  
  let githubClient: some GSApiTransferable = GSGitHubClient<GitHubModel>()
  
  var body: some View {
      VStack { }
  }
}
```
