### PR TITLE
[Chore] #25 GSText의 init 접근제어자를 public으로 명시

### DIFF
--- a/GitSpace/GSDesignSystem/GSText.swift
+++ b/GitSpace/GSDesignSystem/GSText.swift
@@ -20,7 +20,7 @@ public struct GSText: View {
         case description
     }
 
-    init(style: GSTextStyle, string: String) {
+    public init(style: GSTextStyle, string: String) {
         self.style = style
         self.string = string
     }


### PR DESCRIPTION
## 개요
<!-- 무슨 이유로 코드를 변경했는지
어떤 위험이나 장애가 발견되었는지
어떤 부분에 리뷰어가 집중하면 좋을지
관련 스크린샷
테스트 계획 또는 완료 사항 -->
<!-- 1. 먼저 해당 PR과 관련된 issue를 멘션해주세요. -->
<!-- (예시) 
- @issueNumber
- 메인 홈 뷰의 UI를 전체 구현했습니다. 
-->

- GSText의 init이 기본값 internal로 되어 있어 외부 모듈에서 사용할 수 없는 문제가 발생했다. 이를 해결하기 위해 public 제어자를 명시적으로 붙여주었다.
- #25 

## ✏️ 작업 사항
<!-- 2. 작업한 내용을 작성해주세요. -->
<!-- (예시)
- 관리자용 대시보드 구현
- 관리자용 권한 수정 버튼 추가
-->

- GSText의 init 접근제어자를 public으로 명시함

## 주요 로직
<!-- 4. 작업한 사항을 시각적으로 보여줄 수 있다면 첨부 해주세요. -->
##### GSDesignSystem > GSText
```diff
public struct GSText: View {
    ...
-   init(style: GSTextStyle, string: String) {
+   public init(style: GSTextStyle, string: String) {
        self.style = style
        self.string = string
    }
   ...
}
```
