### PR TITLE
[Feat] GitHub API 코드 마이그레이션을 진행했습니다.

### DIFF
--- a/GitSpace/GSNetwork/Network/GitHub/Enumeration/GitHubEndpoint.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Enumeration/GitHubEndpoint.swift
@@ -6,3 +6,172 @@
 //
 
 import Foundation
+
+public enum GitHubEndpoint {
+  case authenticatedUserInformation
+  case authenticatedUserStarRepositories(page: Int)
+  case authenticatedUserRepositories(page: Int)
+  case authenticatedUserFollowers(perPage: Int, page: Int)
+  case authenticatedUserReceivedEvents(userName: String, page: Int)
+  case authenticatedUserFollowsPerson(userName: String)
+  case userInformation(userName: String)
+  case userStarRepositories(userName: String, page: Int)
+  case userFollowingList(userName: String, perPage: Int, page: Int)
+  case userFollowerList(userName: String, perPage: Int, page: Int)
+  case repositoryInformation(owner: String, repositoryName: String)
+  case repositoryREADME(owner: String, repositoryName: String)
+  case markdownToHTML(markdownString: String)
+  case starRepository(owner: String, repositoryName: String)
+  case unstarRepository(owner: String, repositoryName: String)
+  case followUser(userName: String)
+  case unfollowUser(userName: String)
+  case repositoryContributors(owner: String, repositoryName: String, page: Int)
+}
+
+extension GitHubEndpoint: Endpoint {
+  var path: String {
+    switch self {
+    case .authenticatedUserInformation:
+      return "/user"
+    case .authenticatedUserRepositories:
+      return "/user/repos"
+    case .authenticatedUserStarRepositories:
+      return "/user/starred"
+    case .authenticatedUserFollowers:
+      return "/user/followers"
+    case .authenticatedUserReceivedEvents(let userName, _ ):
+      return "/users/\(userName)/received_events"
+    case .authenticatedUserFollowsPerson(let userName):
+      return "/user/following/\(userName)"
+    case .starRepository(let owner, let repositoryName):
+      return "/user/starred/\(owner)/\(repositoryName)"
+    case .unstarRepository(let owner, let repositoryName):
+      return "/user/starred/\(owner)/\(repositoryName)"
+    case .repositoryInformation(let owner, let repositoryName):
+      return "/repos/\(owner)/\(repositoryName)"
+    case .repositoryContributors(let owner, let repositoryName, _ ):
+      return "/repos/\(owner)/\(repositoryName)/contributors"
+    case .repositoryREADME(let owner, let repositoryName):
+      return "/repos/\(owner)/\(repositoryName)/readme"
+    case .markdownToHTML:
+      return "/markdown"
+    case .userInformation(let userName):
+      return "/users/\(userName)"
+    case .userStarRepositories(let userName, _ ):
+      return "/users/\(userName)/starred"
+    case .followUser(let userName):
+      return "/user/following/\(userName)"
+    case .unfollowUser(let userName):
+      return "/user/following/\(userName)"
+    case .userFollowingList(let userName, _, _ ):
+      return "/users/\(userName)/following"
+    case .userFollowerList(let userName, _, _ ):
+      return "/users/\(userName)/followers"
+    }
+  }
+
+  public var method: HTTPRequestMethod {
+    switch self {
+    case .authenticatedUserInformation:
+      return .get
+    case .authenticatedUserStarRepositories:
+      return .get
+    case .authenticatedUserRepositories:
+      return .get
+    case .authenticatedUserFollowers:
+      return .get
+    case .authenticatedUserReceivedEvents:
+      return .get
+    case .authenticatedUserFollowsPerson:
+      return .get
+    case .starRepository:
+      return .put
+    case .unstarRepository:
+      return .delete
+    case .repositoryInformation:
+      return .get
+    case .repositoryContributors:
+      return .get
+    case .repositoryREADME:
+      return .get
+    case .markdownToHTML:
+      return .post
+    case .userInformation:
+      return .get
+    case .userStarRepositories:
+      return .get
+    case .followUser:
+      return .put
+    case .unfollowUser:
+      return .delete
+    case .userFollowingList:
+      return .get
+    case .userFollowerList:
+      return .get
+    }
+  }
+
+  var header: [String: String]? {
+    // FIXME: - accessToken To Keychain, Not UserDefaults
+    guard let accessToken = UserDefaults.standard.string(forKey: "AT") else { return nil }
+
+    switch self {
+    default:
+      return [
+        "Accept": "application/vnd.github+json",
+        "Authorization": "Bearer \(accessToken)",
+        "X-GitHub-Api-Version": "2022-11-28"
+      ]
+    }
+  }
+
+  var body: [String: String]? {
+    switch self {
+    case .markdownToHTML(let markdownString):
+      return [
+        "text": markdownString,
+        "mode": "gfm"
+      ]
+    default:
+      return nil
+    }
+  }
+
+  var queryItems: [URLQueryItem] {
+    switch self {
+    case .authenticatedUserStarRepositories(let page):
+      return [URLQueryItem(name: "page", value: "\(page)")]
+
+    /// defualt는 한 페이지당 30개의 repository 이며, pagenation을 위해 page를 연관값으로 가짐
+    case .authenticatedUserRepositories(let page):
+      return [URLQueryItem(name: "page", value: "\(page)")]
+
+    case .authenticatedUserReceivedEvents(_, let page):
+      return [URLQueryItem(name: "page", value: "\(page)")]
+
+    /// defualt는 한 페이지당 30명의 contributor이며, pagenation을 위해 page를 연관값으로 가짐
+    case .repositoryContributors(_, _, let page):
+      return [URLQueryItem(name: "page", value: "\(page)")]
+
+    case .userStarRepositories(_, let page):
+      return [URLQueryItem(name: "page", value: "\(page)")]
+
+    case .authenticatedUserFollowers(let perPage, let page):
+      return [URLQueryItem(name: "page", value: "\(page)"), URLQueryItem(name: "per_page", value: "\(perPage)")]
+
+    /// default는 한 페이지당 30명의 Following User이며, pagenation을 위해 page를 연관값으로 가짐
+    case .userFollowingList(_, let perPage, let page):
+      return [URLQueryItem(name: "page", value: "\(page)"), URLQueryItem(name: "per_page", value: "\(perPage)")]
+
+    /// default는 한 페이지당 30명의 Follower이며, pagenation을 위해 page를 연관값으로 가짐
+    case .userFollowerList(_, let perPage, let page):
+      return [URLQueryItem(name: "page", value: "\(page)"), URLQueryItem(name: "per_page", value: "\(perPage)")]
+
+    default:
+      return []
+    }
+  }
+
+
+}
+

--- a/GitSpace/GSNetwork/Network/GitHub/Enumeration/GitHubEndpoint.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Enumeration/GitHubEndpoint.swift
@@ -1,0 +1,8 @@
+//
+//  GitHubEndpoint.swift
+//  GSNetwork
+//
+//  Created by 박제균 on 2/14/24.
+//
+
+import Foundation

--- a/GitSpace/GSNetwork/Network/GitHub/Enumeration/HTTPRequestMethod.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Enumeration/HTTPRequestMethod.swift
@@ -1,0 +1,15 @@
+//
+//  HTTPRequestMethod.swift
+//  GSNetwork
+//
+//  Created by 박제균 on 2/14/24.
+//
+
+import Foundation
+
+enum HTTPRequestMethod: String {
+  case get = "GET"
+  case post = "POST"
+  case put = "PUT"
+  case delete = "DELETE"
+}

--- a/GitSpace/GSNetwork/Network/GitHub/Enumeration/HTTPRequestMethod.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Enumeration/HTTPRequestMethod.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum HTTPRequestMethod: String {
+public enum HTTPRequestMethod: String {
   case get = "GET"
   case post = "POST"
   case put = "PUT"

--- a/GitSpace/GSNetwork/Network/GitHub/Error/GitHubError.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Error/GitHubError.swift
@@ -1,0 +1,71 @@
+//
+//  GitHubError.swift
+//  GSNetwork
+//
+//  Created by 박제균 on 2/13/24.
+//
+
+import GSUtilities
+
+public enum GitHubError: GSError {
+  case invalidURL(from: String)
+  case invalidResponse(from: String)
+  case failToDecoding(from: String)
+  case failToEncoding(from: String)
+  case failToLoadREADME(from: String)
+  case unauthorized(from: String)
+  case unexpectedStatusCode(from: String)
+  case notModified(from: String)
+  case requireAuthentication(from: String)
+  case forbidden(from: String)
+  case notFound(from: String)
+  case failToRequest(from: String)
+  case unknown(from: String)
+}
+
+public extension GitHubError {
+
+  var errorDescription: String {
+    switch self {
+    case .invalidURL(let from):
+      return from + "URL was invalid, Please try again."
+
+    case .invalidResponse(let from):
+      return from + "Invalid response from the server. Please try again."
+
+    case .failToDecoding(let from):
+      return from + "Fail to decode data. Please try again"
+
+    case .failToEncoding(let from):
+      return from + "Fail to encode data. Please try again"
+
+    case .unauthorized(let from):
+      return from + "Authorization Failed. Please try again"
+
+    case .unexpectedStatusCode(let from):
+      return from + "Unexpected Error occured. Please try again"
+
+    case .notModified(let from):
+      return from + "No data modification has been made. Please try again"
+
+    case .requireAuthentication(let from):
+      return from + "Authentication is required. Please try again"
+
+    case .forbidden(let from):
+      return from + "This is an invalid permission. Please Try Again"
+
+    case .notFound(let from):
+      return from + "Resources are not found. Please Try Again"
+
+    case .failToLoadREADME(let from):
+      return from + "Fail to load README.md from Server. Please Try Again"
+
+    case .failToRequest(let from):
+      return from + "Fail to Request Network. Please Try Again"
+
+    case .unknown(from: let from):
+      return from + "Unknown Error. Please try Again"
+    }
+  }
+
+}

--- a/GitSpace/GSNetwork/Network/GitHub/Implementation/GitHubService.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Implementation/GitHubService.swift
@@ -6,3 +6,206 @@
 //
 
 import Foundation
+
+final class GitHubService: HTTPClient, GitHubServiceProtocol {
+
+    /**
+     인증된 유저의 계정으로 특정 유저를 팔로우합니다.
+     - Author: 제균
+     - returns: 요청 성공시 성공했다는 string을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestToFollowUser(userName: String) async throws {
+        return try await sendRequest(endpoint: GitHubEndpoint.followUser(userName: userName))
+    }
+
+    /**
+     인증된 유저의 계정으로 특정 유저를 언팔로우합니다.
+     - Author: 제균
+     - returns: 요청 성공시 성공했다는 string을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestToUnfollowUser(userName: String) async throws {
+        return try await sendRequest(endpoint: GitHubEndpoint.unfollowUser(userName: userName))
+    }
+
+    /**
+     인증된 유저가 특정 유저를 팔로우하는지 여부를 API에 요청합니다.
+     - Author: 제균
+     - returns: 요청 성공시 성공했다는 string을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestAuthenticatedUserFollowsPerson(userName: String) async throws {
+        return try await sendRequest(endpoint: GitHubEndpoint.authenticatedUserFollowsPerson(userName: userName))
+    }
+
+    /**
+     인증된 유저의 팔로워 목록을 불러옵니다.
+     - Author: 제균
+     - returns: 요청 성공시 유저 정보 모델을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestAuthenticatedUserFollowers(perPage: Int, page: Int) async -> Result<[FollowerResponse], GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.authenticatedUserFollowers(perPage: 100, page: page))
+    }
+
+    /**
+     인증된 유저의 정보를 요청합니다.
+     - Author: 제균
+     - returns: 요청 성공시 유저 정보 모델을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestAuthenticatedUser() async -> Result<GithubUser, GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.authenticatedUserInformation)
+    }
+
+    /**
+     인증된 유저의 레포지토리 목록를 요청합니다.
+     - Author: 제균
+     - parameters:
+        - page: 요청할 page number
+     - returns: 요청 성공시 유저가 권한을 가진 레포지토리 목록을, 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestAuthenticatedUserRepositories(page: Int) async -> Result<[RepositoryResponse], GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.authenticatedUserRepositories(page: page))
+    }
+
+    /**
+     인증된 유저의 star repositories를 요청합니다.
+     - Author: 제균
+     - parameters:
+        - page: 요청할 page number
+     - returns: 요청 성공시 유저가 star를 눌러둔 레포지토리 목록을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestAuthenticatedUserStars(page: Int) async -> Result<[RepositoryResponse], GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.authenticatedUserStarRepositories(page: page))
+    }
+
+    /**
+     인증된 유저의 received events를 요청합니다.
+     - Author: 제균
+     - parameters:
+        - page: 요청할 page number
+     - returns: 요청 성공시 유저가 받은 Event 목록을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestAuthenticatedUserReceivedEvents(userName: String, page: Int) async -> Result<[Event], GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.authenticatedUserReceivedEvents(userName: userName, page: page))
+    }
+
+    /**
+     인증된 사용자의 계정으로 특정 레포지토리를 star하는 PUT 요청을 보냅니다.
+     - Author: 제균
+     - parameters:
+        - owner: 레포지토리 주인의 userName
+        - repositoryName: star를 누를 대상 레포지토리의 이름
+     - returns: 요청 성공시 성공했다는 string을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestToStarRepository(owner: String, repositoryName: String) async throws {
+        return try await sendRequest(endpoint: GitHubEndpoint.starRepository(owner: owner, repositoryName: repositoryName))
+    }
+
+    /**
+     인증된 사용자의 계정으로 특정 레포지토리를 star하는 DELETE 요청을 보냅니다.
+     - Author: 제균
+     - parameters:
+        - owner: 레포지토리 주인의 userName
+        - repositoryName: star를 해제할 대상 레포지토리의 이름
+     - returns: 요청 성공시 성공했다는 string을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestToUnstarRepository(owner: String, repositoryName: String) async throws {
+        return try await sendRequest(endpoint: GitHubEndpoint.unstarRepository(owner: owner, repositoryName: repositoryName))
+    }
+
+    /**
+     특정 유저의 Public 정보를 요청합니다.
+     - Author: 제균
+     - parameters:
+        - userName: GitHub userName
+     - returns: 요청 성공시 유저 정보 모델을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestUserInformation(userName: String) async -> Result<GithubUser, GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.userInformation(userName: userName))
+    }
+
+    /**
+     특정 유저의 starred repository 정보를 요청합니다.
+     - Author: 제균
+     - parameters:
+        - userName: GitHub userName
+        - page: 요청할 page number
+     - returns: 요청 성공시 특정 유저가 star를 눌러둔 레포지토리 목록을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestUserStarRepositories(userName: String, page: Int) async -> Result<[RepositoryResponse], GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.userStarRepositories(userName: userName, page: page))
+    }
+
+    /**
+     특정 유저의 Following List 정보를 요청합니다.
+     - Author: 한호
+     - parameters:
+        - userName: GitHub userName
+        - perPage: page 당 요청할 개수(default: 30, max: 100)
+        - page: 요청할 page number
+     - returns: 요청 성공시 특정 유저의 Following 목록을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestUserFollowingList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.userFollowingList(userName: userName, perPage: perPage, page: page))
+    }
+
+    /**
+     특정 유저의 Follower List 정보를 요청합니다.
+     - Author: 한호
+     - parameters:
+        - userName: GitHub userName
+        - perPage: page 당 요청할 개수(default: 30, max: 100)
+        - page: 요청할 page numbe
+     - returns: 요청 성공시 특정 유저의 Follower 목록을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestUserFollowerList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.userFollowerList(userName: userName, perPage: perPage, page: page))
+    }
+
+    /**
+     특정 레포지토리의 정보를 요청합니다.
+     - Author: 제균
+     - parameters:
+        - owner: 레포지토리 주인의 userName
+        - repositoryName: 레포지토리의 이름
+     - returns: 요청 성공시 레포지토리 모델을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestRepositoryInformation(owner: String, repositoryName: String) async -> Result<Repository, GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.repositoryInformation(owner: owner, repositoryName: repositoryName))
+    }
+
+    /**
+     특정 레포지토리의 리드미를 요청합니다.
+     - Author: 제균
+     - parameters:
+        - owner: 레포지토리 주인의 userName
+        - repositoryName: 레포지토리의 이름
+     - returns: 요청 성공시 레포지토리의 readme를 담고있는 모델을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestRepositoryReadme(owner: String, repositoryName: String) async -> Result<RepositoryReadmeResponse, GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.repositoryREADME(owner: owner, repositoryName: repositoryName))
+    }
+
+    /**
+     마크다운 String을 HTML String으로 변환하도록 요청합니다.
+     - Author: 제균
+     - parameters:
+        - content: html 문자열로 변환할 마크다운 문자열
+     - returns: 요청 성공시 HTML 문자열을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestMarkdownToHTML(content: String) async -> Result<String, GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.markdownToHTML(markdownString: content))
+    }
+
+    /**
+     특정 레포지토리의 contributor 목록을 요청합니다.
+     - Author: 제균
+     - parameters:
+        - owner: 레포지토리 주인의 userName
+        - repositoryName: 대상 레포지토리의 이름
+        - page: 요청할 페이지 number
+     - returns: 요청 성공시 성공했다는 Contributor의 목록을, 요청 실패시 GitHubAPIError를 가지는 Result 타입을 리턴합니다.
+     */
+    func requestRepositoryContributors(owner: String, repositoryName: String, page: Int) async -> Result<[ContributorProfile], GitHubError> {
+        return await sendRequest(endpoint: GitHubEndpoint.repositoryContributors(owner: owner, repositoryName: repositoryName, page: page))
+    }
+
+}

--- a/GitSpace/GSNetwork/Network/GitHub/Implementation/GitHubService.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Implementation/GitHubService.swift
@@ -1,0 +1,8 @@
+//
+//  GitHubService.swift
+//  GSNetwork
+//
+//  Created by 박제균 on 2/14/24.
+//
+
+import Foundation

--- a/GitSpace/GSNetwork/Network/GitHub/Protocol/Endpoint.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Protocol/Endpoint.swift
@@ -1,0 +1,27 @@
+//
+//  Endpoint.swift
+//  GSNetwork
+//
+//  Created by 박제균 on 2/14/24.
+//
+
+import Foundation
+
+protocol Endpoint {
+  var scheme: String { get }
+  var host: String { get }
+  var path: String { get }
+  var method: HTTPRequestMethod { get }
+  var header: [String: String]? { get }
+  var body: [String: String]? { get }
+  var queryItems: [URLQueryItem] { get }
+}
+
+extension Endpoint {
+  var scheme: String {
+    return "https"
+  }
+  var host: String {
+    return "api.github.com"
+  }
+}

--- a/GitSpace/GSNetwork/Network/GitHub/Protocol/Endpoint.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Protocol/Endpoint.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol Endpoint {
+public protocol Endpoint {
   var scheme: String { get }
   var host: String { get }
   var path: String { get }

--- a/GitSpace/GSNetwork/Network/GitHub/Protocol/Endpoint.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Protocol/Endpoint.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol Endpoint {
+protocol Endpoint {
   var scheme: String { get }
   var host: String { get }
   var path: String { get }

--- a/GitSpace/GSNetwork/Network/GitHub/Protocol/GitHubServiceProtocol.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Protocol/GitHubServiceProtocol.swift
@@ -1,0 +1,67 @@
+//
+//  GitHubServiceProtocol.swift
+//  GSNetwork
+//
+//  Created by 박제균 on 2/14/24.
+//
+
+import Foundation
+
+protocol GitHubServiceProtocol {
+
+    /// 인증된 사용자의 정보를 요청하는 함수
+    func requestAuthenticatedUser() async -> Result<GithubUser, GitHubError>
+
+    /// 인증된 사용자의 starred repository들을 요청하는 함수
+    func requestAuthenticatedUserStars(page: Int) async -> Result<[RepositoryResponse], GitHubError>
+
+    /// 인증된 사용자가 액세스 권한을 가진 repository들을 요청하는 함수
+    func requestAuthenticatedUserRepositories(page: Int) async -> Result<[RepositoryResponse], GitHubError>
+
+    /// 인증된 사용자가 팔로우하고 있는지의 여부를 확인하는 함수
+    func requestAuthenticatedUserFollowsPerson(userName: String) async throws
+
+    /// 인증된 사용자의 follower 목록을 요청하는 함수
+    func requestAuthenticatedUserFollowers(perPage: Int, page: Int) async -> Result<[FollowerResponse], GitHubError>
+
+    /// 인증된 사용자로 받은 이벤트를 요청하는 함수
+    func requestAuthenticatedUserReceivedEvents(userName: String, page: Int) async -> Result<[Event],GitHubError>
+
+    /// 인증된 사용자로 특정 레포지토리를 star할 때 사용하는 함수
+    func requestToStarRepository(owner: String, repositoryName: String) async throws
+
+    /// 인증된 사용자로 특정 레포지토리를 unstar할 때 사용하는 함수
+    func requestToUnstarRepository(owner: String, repositoryName: String) async throws
+
+    /// 특정 유저를 follow 할 때 사용하는 함수
+    func requestToFollowUser(userName: String) async throws
+
+    // 특정 유저를 unfollow 할 때 사용하는 함수
+    func requestToUnfollowUser(userName: String) async throws
+
+    /// 특정 유저의 정보를 요청하는 함수
+    func requestUserInformation(userName: String) async -> Result<GithubUser, GitHubError>
+
+    /// 특정 유저의 starred repository들을 요청하는 함수
+    func requestUserStarRepositories(userName: String, page: Int) async -> Result<[RepositoryResponse], GitHubError>
+
+    /// 특정 유저의 Following List를 요청하는 함수
+    func requestUserFollowingList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubError>
+
+    /// 특정 유저의 Follower List를 요청하는 함수
+    func requestUserFollowerList(userName: String, perPage: Int, page: Int) async -> Result<[FollowingResponse], GitHubError>
+
+    /// 특정 레포지토리의 정보를 요청하는 함수
+    func requestRepositoryInformation(owner: String, repositoryName: String) async -> Result<Repository, GitHubError>
+
+    /// 특정 레포지토리의 리드미를 요청하는 함수
+    func requestRepositoryReadme(owner: String, repositoryName: String) async -> Result<RepositoryReadmeResponse, GitHubError>
+
+    /// 마크다운 text를 HTML로 변환하는 함수
+    func requestMarkdownToHTML(content: String) async -> Result<String, GitHubError>
+
+    /// 특정 레포지토리의 contributor 목록을 요청하는 함수
+    func requestRepositoryContributors(owner: String, repositoryName: String, page: Int) async -> Result<[ContributorProfile], GitHubError>
+
+    // TODO: - 필요한 API 기능을 추가로 작성합니다.
+}

--- a/GitSpace/GSNetwork/Network/GitHub/Protocol/HTTPClient.swift
+++ b/GitSpace/GSNetwork/Network/GitHub/Protocol/HTTPClient.swift
@@ -1,0 +1,167 @@
+//
+//  HTTPClient.swift
+//  GSNetwork
+//
+//  Created by 박제균 on 2/14/24.
+//
+
+import Foundation
+
+protocol HTTPClient {
+
+  /// HTTP request를 보내고, 성공시 지정한 model을 돌려받을 수 있다. 실패시 error를 받는다.
+  func sendRequest<T: Decodable>(endpoint: Endpoint) async -> Result<T, GitHubError>
+
+  ///response로 status code와 함께 string을 받는 경우(Markdown)
+  func sendRequest(endpoint: Endpoint) async -> Result<String, GitHubError>
+
+  /// response로 status code만 받는 경우 (star, unstar, follow, unfollow)
+  /// status code만 받기 때문에, 204를 만나면 break, 나머지 코드를 받으면 error를 throw한다.
+  func sendRequest(endpoint: Endpoint) async throws
+}
+
+extension HTTPClient {
+
+  func sendRequest<T: Decodable>(endpoint: Endpoint) async -> Result<T, GitHubError> {
+
+    var components = URLComponents()
+    components.scheme = endpoint.scheme
+    components.host = endpoint.host
+    components.path = endpoint.path
+    components.queryItems = endpoint.queryItems
+
+    guard let url = components.url else {
+      return .failure(.invalidURL(from: #function))
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = endpoint.method.rawValue
+    request.allHTTPHeaderFields = endpoint.header
+
+    if let body = endpoint.body {
+      request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
+    }
+
+    do {
+      let (data, response) = try await URLSession.shared.data(for: request)
+
+      guard let response = response as? HTTPURLResponse else {
+        return .failure(.invalidResponse(from: #function))
+      }
+
+      switch response.statusCode {
+      case 200...299:
+        guard let decodedResponse = try? JSONDecoder().decode(T.self, from: data) else {
+          return .failure(.failToDecoding(from: #function))
+        }
+        return .success(decodedResponse)
+      default:
+        return .failure(.unexpectedStatusCode(from: #function))
+      }
+
+    } catch {
+      return .failure(.unknown(from: #function))
+    }
+  }
+
+  func sendRequest(endpoint: Endpoint) async -> Result<String, GitHubError> {
+    var components = URLComponents()
+    components.scheme = endpoint.scheme
+    components.host = endpoint.host
+    components.path = endpoint.path
+    components.queryItems = endpoint.queryItems
+
+    guard let url = components.url else {
+      return .failure(.invalidURL(from: #function))
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = endpoint.method.rawValue
+    request.allHTTPHeaderFields = endpoint.header
+
+    if let body = endpoint.body {
+      request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
+    }
+
+    do {
+      let (data, response) = try await URLSession.shared.data(for: request)
+
+      guard let response = response as? HTTPURLResponse else {
+        return .failure(.invalidResponse(from: #function))
+      }
+
+      switch response.statusCode {
+
+      case 200:
+        guard let resultString = String(data: data, encoding: .utf8) else {
+          return .failure(.failToEncoding(from: #function))
+        }
+        return .success(resultString)
+      case 204:
+        return .success("request succeed")
+      case 304:
+        return .failure(.notModified(from: #function))
+      case 401:
+        return .failure(.requireAuthentication(from: #function))
+      case 403:
+        return .failure(.forbidden(from: #function))
+      case 404:
+        return .failure(.notFound(from: #function))
+      default:
+        return .failure(.unexpectedStatusCode(from: #function))
+      }
+    } catch {
+      return .failure(.unknown(from: #function))
+    }
+  }
+
+  func sendRequest(endpoint: Endpoint) async throws {
+    var components = URLComponents()
+    components.scheme = endpoint.scheme
+    components.host = endpoint.host
+    components.path = endpoint.path
+    components.queryItems = endpoint.queryItems
+
+    guard let url = components.url else {
+      throw GitHubError.invalidURL(from: #function)
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = endpoint.method.rawValue
+    request.allHTTPHeaderFields = endpoint.header
+
+    if let body = endpoint.body {
+      request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
+    }
+
+    do {
+      let ( _, response) = try await URLSession.shared.data(for: request)
+
+      guard let response = response as? HTTPURLResponse else {
+        throw GitHubError.invalidResponse(from: #function)
+      }
+
+      switch response.statusCode {
+        // 204를 만나면 에러 없이 종료
+      case 204:
+        break
+      case 304:
+        throw GitHubError.notModified(from: #function)
+      case 401:
+        throw GitHubError.requireAuthentication(from: #function)
+      case 403:
+        throw GitHubError.forbidden(from: #function)
+      case 404:
+        throw GitHubError.notFound(from: #function)
+      default:
+        throw GitHubError.unexpectedStatusCode(from: #function)
+      }
+
+    } catch {
+      throw GitHubError.unknown(from: #function)
+    }
+  }
+
+}
+
+

--- a/GitSpace/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace/GitSpace.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2246C8362B7B46DB006F79E1 /* GitHubError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2246C8352B7B46DB006F79E1 /* GitHubError.swift */; };
+		2246C83A2B7B4F04006F79E1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2246C8392B7B4F04006F79E1 /* GoogleService-Info.plist */; };
 		22CDB98F2AD7C9F400F22ADA /* GSText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDB98E2AD7C9F400F22ADA /* GSText.swift */; };
 		681C742D2AE1611200651D3E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 681C742C2AE1611200651D3E /* .swiftlint.yml */; };
 		6E15595A2ACEFFCA003972BD /* GSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1559592ACEFFCA003972BD /* GSButton.swift */; };
@@ -130,6 +132,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2246C8352B7B46DB006F79E1 /* GitHubError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubError.swift; sourceTree = "<group>"; };
+		2246C8392B7B4F04006F79E1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		22CDB98E2AD7C9F400F22ADA /* GSText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSText.swift; sourceTree = "<group>"; };
 		681C742C2AE1611200651D3E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6E1559592ACEFFCA003972BD /* GSButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSButton.swift; sourceTree = "<group>"; };
@@ -239,6 +243,7 @@
 		2246C8312B7B40F3006F79E1 /* Error */ = {
 			isa = PBXGroup;
 			children = (
+				2246C8352B7B46DB006F79E1 /* GitHubError.swift */,
 			);
 			path = Error;
 			sourceTree = "<group>";
@@ -463,6 +468,7 @@
 			isa = PBXGroup;
 			children = (
 				6E9AEBD82B62866700E10516 /* GoogleService-Info.plist */,
+				2246C8392B7B4F04006F79E1 /* GoogleService-Info.plist */,
 				7E65A94E2ACEEA3200C9BEA3 /* GitSpaceApp.swift */,
 				7E65A9502ACEEA3200C9BEA3 /* ContentView.swift */,
 				7E65A9522ACEEA3300C9BEA3 /* Assets.xcassets */,
@@ -702,6 +708,7 @@
 			files = (
 				681C742D2AE1611200651D3E /* .swiftlint.yml in Resources */,
 				6E9AEBD92B62866700E10516 /* GoogleService-Info.plist in Resources */,
+				2246C83A2B7B4F04006F79E1 /* GoogleService-Info.plist in Resources */,
 				7E65A9562ACEEA3300C9BEA3 /* Preview Assets.xcassets in Resources */,
 				7E65A9532ACEEA3300C9BEA3 /* Assets.xcassets in Resources */,
 			);
@@ -759,6 +766,7 @@
 				6EF1F4EA2B58A1BF00CD247D /* GithubUser.swift in Sources */,
 				6EF1F4E22B58A1BF00CD247D /* FirestoreFieldProtocol.swift in Sources */,
 				6EF1F4EB2B58A1BF00CD247D /* Repository.swift in Sources */,
+				2246C8362B7B46DB006F79E1 /* GitHubError.swift in Sources */,
 				6EF1F4F32B58A1BF00CD247D /* Knock.swift in Sources */,
 				6EF1F4E32B58A1BF00CD247D /* Chat.swift in Sources */,
 				6EF1F4F42B58A1BF00CD247D /* FirestoreField.swift in Sources */,
@@ -839,14 +847,16 @@
 		6EF1F4DC2B58A17300CD247D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 75QZ7682T2;
+				DEVELOPMENT_TEAM = QY2NR7SV42;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -877,14 +887,16 @@
 		6EF1F4DD2B58A17300CD247D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 75QZ7682T2;
+				DEVELOPMENT_TEAM = QY2NR7SV42;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1042,7 +1054,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"GitSpace/Preview Content\"";
-				DEVELOPMENT_TEAM = 75QZ7682T2;
+				DEVELOPMENT_TEAM = QY2NR7SV42;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -1072,7 +1084,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"GitSpace/Preview Content\"";
-				DEVELOPMENT_TEAM = 75QZ7682T2;
+				DEVELOPMENT_TEAM = QY2NR7SV42;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -1097,11 +1109,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 75QZ7682T2;
+				DEVELOPMENT_TEAM = QY2NR7SV42;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1133,11 +1145,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 75QZ7682T2;
+				DEVELOPMENT_TEAM = QY2NR7SV42;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1172,7 +1184,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 75QZ7682T2;
+				DEVELOPMENT_TEAM = QY2NR7SV42;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1208,7 +1220,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 75QZ7682T2;
+				DEVELOPMENT_TEAM = QY2NR7SV42;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/GitSpace/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace/GitSpace.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		2246C8362B7B46DB006F79E1 /* GitHubError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2246C8352B7B46DB006F79E1 /* GitHubError.swift */; };
 		2246C83A2B7B4F04006F79E1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2246C8392B7B4F04006F79E1 /* GoogleService-Info.plist */; };
+		224A8FF12B7BBFB800C003A4 /* HTTPRequestMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF02B7BBFB800C003A4 /* HTTPRequestMethod.swift */; };
 		22CDB98F2AD7C9F400F22ADA /* GSText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDB98E2AD7C9F400F22ADA /* GSText.swift */; };
 		681C742D2AE1611200651D3E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 681C742C2AE1611200651D3E /* .swiftlint.yml */; };
 		6E15595A2ACEFFCA003972BD /* GSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1559592ACEFFCA003972BD /* GSButton.swift */; };
@@ -134,6 +135,7 @@
 /* Begin PBXFileReference section */
 		2246C8352B7B46DB006F79E1 /* GitHubError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubError.swift; sourceTree = "<group>"; };
 		2246C8392B7B4F04006F79E1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		224A8FF02B7BBFB800C003A4 /* HTTPRequestMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestMethod.swift; sourceTree = "<group>"; };
 		22CDB98E2AD7C9F400F22ADA /* GSText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSText.swift; sourceTree = "<group>"; };
 		681C742C2AE1611200651D3E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6E1559592ACEFFCA003972BD /* GSButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSButton.swift; sourceTree = "<group>"; };
@@ -251,6 +253,7 @@
 		2246C8322B7B4137006F79E1 /* Enumeration */ = {
 			isa = PBXGroup;
 			children = (
+				224A8FF02B7BBFB800C003A4 /* HTTPRequestMethod.swift */,
 			);
 			path = Enumeration;
 			sourceTree = "<group>";
@@ -774,6 +777,7 @@
 				6EF1F4F02B58A1BF00CD247D /* FollowerResponse.swift in Sources */,
 				6EF1F4E92B58A1BF00CD247D /* Tag.swift in Sources */,
 				6EF1F4F12B58A1BF00CD247D /* FirestoreCollection.swift in Sources */,
+				224A8FF12B7BBFB800C003A4 /* HTTPRequestMethod.swift in Sources */,
 				6EF1F4EE2B58A1BF00CD247D /* RepositoryResponse.swift in Sources */,
 				6EF1F4F22B58A1BF00CD247D /* FollowingResponse.swift in Sources */,
 				6EF1F4F72B58A1BF00CD247D /* FirestoreError.swift in Sources */,

--- a/GitSpace/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace/GitSpace.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		224A8FF12B7BBFB800C003A4 /* HTTPRequestMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF02B7BBFB800C003A4 /* HTTPRequestMethod.swift */; };
 		224A8FF32B7BC0E900C003A4 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF22B7BC0E900C003A4 /* Endpoint.swift */; };
 		224A8FF52B7BC2A600C003A4 /* GitHubEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF42B7BC2A600C003A4 /* GitHubEndpoint.swift */; };
+		224A8FF72B7C9EB200C003A4 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF62B7C9EB200C003A4 /* HTTPClient.swift */; };
 		22CDB98F2AD7C9F400F22ADA /* GSText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDB98E2AD7C9F400F22ADA /* GSText.swift */; };
 		681C742D2AE1611200651D3E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 681C742C2AE1611200651D3E /* .swiftlint.yml */; };
 		6E15595A2ACEFFCA003972BD /* GSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1559592ACEFFCA003972BD /* GSButton.swift */; };
@@ -140,6 +141,7 @@
 		224A8FF02B7BBFB800C003A4 /* HTTPRequestMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestMethod.swift; sourceTree = "<group>"; };
 		224A8FF22B7BC0E900C003A4 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		224A8FF42B7BC2A600C003A4 /* GitHubEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubEndpoint.swift; sourceTree = "<group>"; };
+		224A8FF62B7C9EB200C003A4 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		22CDB98E2AD7C9F400F22ADA /* GSText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSText.swift; sourceTree = "<group>"; };
 		681C742C2AE1611200651D3E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6E1559592ACEFFCA003972BD /* GSButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSButton.swift; sourceTree = "<group>"; };
@@ -267,6 +269,7 @@
 			isa = PBXGroup;
 			children = (
 				224A8FF22B7BC0E900C003A4 /* Endpoint.swift */,
+				224A8FF62B7C9EB200C003A4 /* HTTPClient.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -776,6 +779,7 @@
 				6EF1F4EA2B58A1BF00CD247D /* GithubUser.swift in Sources */,
 				6EF1F4E22B58A1BF00CD247D /* FirestoreFieldProtocol.swift in Sources */,
 				6EF1F4EB2B58A1BF00CD247D /* Repository.swift in Sources */,
+				224A8FF72B7C9EB200C003A4 /* HTTPClient.swift in Sources */,
 				2246C8362B7B46DB006F79E1 /* GitHubError.swift in Sources */,
 				6EF1F4F32B58A1BF00CD247D /* Knock.swift in Sources */,
 				6EF1F4E32B58A1BF00CD247D /* Chat.swift in Sources */,

--- a/GitSpace/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace/GitSpace.xcodeproj/project.pbxproj
@@ -225,9 +225,49 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2246C8302B7B40E6006F79E1 /* GitHub */ = {
+			isa = PBXGroup;
+			children = (
+				2246C8342B7B415D006F79E1 /* Implementation */,
+				2246C8332B7B4153006F79E1 /* Protocol */,
+				2246C8322B7B4137006F79E1 /* Enumeration */,
+				2246C8312B7B40F3006F79E1 /* Error */,
+			);
+			path = GitHub;
+			sourceTree = "<group>";
+		};
+		2246C8312B7B40F3006F79E1 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
+		2246C8322B7B4137006F79E1 /* Enumeration */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Enumeration;
+			sourceTree = "<group>";
+		};
+		2246C8332B7B4153006F79E1 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
+		2246C8342B7B415D006F79E1 /* Implementation */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Implementation;
+			sourceTree = "<group>";
+		};
 		6E1E7FEF2B4E5DFD00655B04 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				2246C8302B7B40E6006F79E1 /* GitHub */,
 				6EF97FDC2B4E7764007C7932 /* Firestore */,
 			);
 			path = Network;

--- a/GitSpace/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace/GitSpace.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2246C83A2B7B4F04006F79E1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2246C8392B7B4F04006F79E1 /* GoogleService-Info.plist */; };
 		224A8FF12B7BBFB800C003A4 /* HTTPRequestMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF02B7BBFB800C003A4 /* HTTPRequestMethod.swift */; };
 		224A8FF32B7BC0E900C003A4 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF22B7BC0E900C003A4 /* Endpoint.swift */; };
+		224A8FF52B7BC2A600C003A4 /* GitHubEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF42B7BC2A600C003A4 /* GitHubEndpoint.swift */; };
 		22CDB98F2AD7C9F400F22ADA /* GSText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDB98E2AD7C9F400F22ADA /* GSText.swift */; };
 		681C742D2AE1611200651D3E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 681C742C2AE1611200651D3E /* .swiftlint.yml */; };
 		6E15595A2ACEFFCA003972BD /* GSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1559592ACEFFCA003972BD /* GSButton.swift */; };
@@ -138,6 +139,7 @@
 		2246C8392B7B4F04006F79E1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		224A8FF02B7BBFB800C003A4 /* HTTPRequestMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestMethod.swift; sourceTree = "<group>"; };
 		224A8FF22B7BC0E900C003A4 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
+		224A8FF42B7BC2A600C003A4 /* GitHubEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubEndpoint.swift; sourceTree = "<group>"; };
 		22CDB98E2AD7C9F400F22ADA /* GSText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSText.swift; sourceTree = "<group>"; };
 		681C742C2AE1611200651D3E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6E1559592ACEFFCA003972BD /* GSButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSButton.swift; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 			isa = PBXGroup;
 			children = (
 				224A8FF02B7BBFB800C003A4 /* HTTPRequestMethod.swift */,
+				224A8FF42B7BC2A600C003A4 /* GitHubEndpoint.swift */,
 			);
 			path = Enumeration;
 			sourceTree = "<group>";
@@ -783,6 +786,7 @@
 				6EF1F4F12B58A1BF00CD247D /* FirestoreCollection.swift in Sources */,
 				224A8FF12B7BBFB800C003A4 /* HTTPRequestMethod.swift in Sources */,
 				6EF1F4EE2B58A1BF00CD247D /* RepositoryResponse.swift in Sources */,
+				224A8FF52B7BC2A600C003A4 /* GitHubEndpoint.swift in Sources */,
 				6EF1F4F22B58A1BF00CD247D /* FollowingResponse.swift in Sources */,
 				6EF1F4F72B58A1BF00CD247D /* FirestoreError.swift in Sources */,
 				6EF1F4F52B58A1BF00CD247D /* GSModel.swift in Sources */,

--- a/GitSpace/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace/GitSpace.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		224A8FF32B7BC0E900C003A4 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF22B7BC0E900C003A4 /* Endpoint.swift */; };
 		224A8FF52B7BC2A600C003A4 /* GitHubEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF42B7BC2A600C003A4 /* GitHubEndpoint.swift */; };
 		224A8FF72B7C9EB200C003A4 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF62B7C9EB200C003A4 /* HTTPClient.swift */; };
+		224A8FF92B7CA4ED00C003A4 /* GitHubServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF82B7CA4ED00C003A4 /* GitHubServiceProtocol.swift */; };
+		224A8FFB2B7CA6A300C003A4 /* GitHubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FFA2B7CA6A300C003A4 /* GitHubService.swift */; };
 		22CDB98F2AD7C9F400F22ADA /* GSText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDB98E2AD7C9F400F22ADA /* GSText.swift */; };
 		681C742D2AE1611200651D3E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 681C742C2AE1611200651D3E /* .swiftlint.yml */; };
 		6E15595A2ACEFFCA003972BD /* GSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1559592ACEFFCA003972BD /* GSButton.swift */; };
@@ -142,6 +144,8 @@
 		224A8FF22B7BC0E900C003A4 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		224A8FF42B7BC2A600C003A4 /* GitHubEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubEndpoint.swift; sourceTree = "<group>"; };
 		224A8FF62B7C9EB200C003A4 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
+		224A8FF82B7CA4ED00C003A4 /* GitHubServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubServiceProtocol.swift; sourceTree = "<group>"; };
+		224A8FFA2B7CA6A300C003A4 /* GitHubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubService.swift; sourceTree = "<group>"; };
 		22CDB98E2AD7C9F400F22ADA /* GSText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSText.swift; sourceTree = "<group>"; };
 		681C742C2AE1611200651D3E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6E1559592ACEFFCA003972BD /* GSButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSButton.swift; sourceTree = "<group>"; };
@@ -270,6 +274,7 @@
 			children = (
 				224A8FF22B7BC0E900C003A4 /* Endpoint.swift */,
 				224A8FF62B7C9EB200C003A4 /* HTTPClient.swift */,
+				224A8FF82B7CA4ED00C003A4 /* GitHubServiceProtocol.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -277,6 +282,7 @@
 		2246C8342B7B415D006F79E1 /* Implementation */ = {
 			isa = PBXGroup;
 			children = (
+				224A8FFA2B7CA6A300C003A4 /* GitHubService.swift */,
 			);
 			path = Implementation;
 			sourceTree = "<group>";
@@ -772,6 +778,7 @@
 				6EF1F4E82B58A1BF00CD247D /* Event.swift in Sources */,
 				6EF1F4EF2B58A1BF00CD247D /* FirestoreService.swift in Sources */,
 				6EF1F4EC2B58A1BF00CD247D /* LiveFirestoreService.swift in Sources */,
+				224A8FF92B7CA4ED00C003A4 /* GitHubServiceProtocol.swift in Sources */,
 				6EF1F4E42B58A1BF00CD247D /* FirestoreSchema.swift in Sources */,
 				224A8FF32B7BC0E900C003A4 /* Endpoint.swift in Sources */,
 				6EF1F4F82B58A1BF00CD247D /* UserInfo.swift in Sources */,
@@ -800,6 +807,7 @@
 				6EF1F5052B58A2E300CD247D /* Query+.swift in Sources */,
 				6EF1F4E72B58A1BF00CD247D /* Message.swift in Sources */,
 				6EF1F4F62B58A1BF00CD247D /* UserResponse.swift in Sources */,
+				224A8FFB2B7CA6A300C003A4 /* GitHubService.swift in Sources */,
 				6EF1F4FA2B58A1BF00CD247D /* ContributorProfile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GitSpace/GitSpace.xcodeproj/project.pbxproj
+++ b/GitSpace/GitSpace.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2246C8362B7B46DB006F79E1 /* GitHubError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2246C8352B7B46DB006F79E1 /* GitHubError.swift */; };
 		2246C83A2B7B4F04006F79E1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2246C8392B7B4F04006F79E1 /* GoogleService-Info.plist */; };
 		224A8FF12B7BBFB800C003A4 /* HTTPRequestMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF02B7BBFB800C003A4 /* HTTPRequestMethod.swift */; };
+		224A8FF32B7BC0E900C003A4 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A8FF22B7BC0E900C003A4 /* Endpoint.swift */; };
 		22CDB98F2AD7C9F400F22ADA /* GSText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CDB98E2AD7C9F400F22ADA /* GSText.swift */; };
 		681C742D2AE1611200651D3E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 681C742C2AE1611200651D3E /* .swiftlint.yml */; };
 		6E15595A2ACEFFCA003972BD /* GSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1559592ACEFFCA003972BD /* GSButton.swift */; };
@@ -136,6 +137,7 @@
 		2246C8352B7B46DB006F79E1 /* GitHubError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubError.swift; sourceTree = "<group>"; };
 		2246C8392B7B4F04006F79E1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		224A8FF02B7BBFB800C003A4 /* HTTPRequestMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestMethod.swift; sourceTree = "<group>"; };
+		224A8FF22B7BC0E900C003A4 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		22CDB98E2AD7C9F400F22ADA /* GSText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSText.swift; sourceTree = "<group>"; };
 		681C742C2AE1611200651D3E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6E1559592ACEFFCA003972BD /* GSButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSButton.swift; sourceTree = "<group>"; };
@@ -261,6 +263,7 @@
 		2246C8332B7B4153006F79E1 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
+				224A8FF22B7BC0E900C003A4 /* Endpoint.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -764,6 +767,7 @@
 				6EF1F4EF2B58A1BF00CD247D /* FirestoreService.swift in Sources */,
 				6EF1F4EC2B58A1BF00CD247D /* LiveFirestoreService.swift in Sources */,
 				6EF1F4E42B58A1BF00CD247D /* FirestoreSchema.swift in Sources */,
+				224A8FF32B7BC0E900C003A4 /* Endpoint.swift in Sources */,
 				6EF1F4F82B58A1BF00CD247D /* UserInfo.swift in Sources */,
 				6EF1F4E62B58A1BF00CD247D /* Owner.swift in Sources */,
 				6EF1F4EA2B58A1BF00CD247D /* GithubUser.swift in Sources */,


### PR DESCRIPTION
## 개요
- #24
- Network 모듈에 기존 GitHub API 코드를 마이그레이션했습니다.

## ✏️ 작업 사항
<!-- 2. 작업한 내용을 작성해주세요. -->
<!-- (예시)
- 관리자용 대시보드 구현
- 관리자용 권한 수정 버튼 추가
-->

- 기존 HTTPClient 프로토콜 에서 사용되지 않는 파라미터를 제거했습니다.
- 그 외 코드는 대부분 동일하며, GitHubError 열거형의 연관값으로 String을 받아 #function을 입력하여 디버깅이 용이하도록 변경하였습니다. 
- (#21 참고)

## 주요 로직

##### HTTPClient
```diff
- func sendRequest<T: Decodable>(endpoint: Endpoint, responseModel: T.Type) async -> Result<T, GitHubError>
+ func sendRequest<T: Decodable>(endpoint: Endpoint) async -> Result<T, GitHubError>
```

- Closes #24 